### PR TITLE
Fix Windows crash in instrumentation hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitenvs",
-  "version": "2.1.15",
+  "version": "2.1.16",
   "private": false,
   "license": "MIT",
   "description": "Store your environment variables in git – encrypted.",

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -2,11 +2,17 @@ import { getEncryptionTokenOnServer } from './utils/getEncryptionKeyOnServer'
 
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
-    const { default: open } = await import('open')
-    await open(
-      `http://localhost:${
-        process.env.PORT ?? 3000
-      }/#token=${getEncryptionTokenOnServer()}`,
-    )
+    const url = `http://localhost:${
+      process.env.PORT ?? 3000
+    }/#token=${getEncryptionTokenOnServer()}`
+
+    const { exec } = await import('node:child_process')
+    const command =
+      process.platform === 'win32'
+        ? `start "" "${url}"`
+        : process.platform === 'darwin'
+          ? `open "${url}"`
+          : `xdg-open "${url}"`
+    exec(command)
   }
 }


### PR DESCRIPTION
## Summary
- Replace `open` npm package with `node:child_process` in the instrumentation hook
- The `open` package was bundled by Next.js standalone build with absolute Linux CI paths (`file:///home/runner/work/...`), causing `ERR_INVALID_FILE_URL_PATH` on Windows
- `node:child_process` is a Node.js built-in that never gets bundled, avoiding cross-platform path issues

## Test plan
- [ ] Run `npm run gitenvs` on Windows and verify the browser opens without errors
- [ ] Run on macOS/Linux to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)