### PR TITLE
Refactor environment variable creation across components

### DIFF
--- a/@/components/AddNewEnvVar.tsx
+++ b/@/components/AddNewEnvVar.tsx
@@ -1,7 +1,7 @@
 import { encryptEnvVar } from '@/gitenvs/encryptEnvVar'
+import { createEnvVar } from '@/gitenvs/createEnvVar'
 import { saveGitenvs } from '@/gitenvs/gitenvs'
-import { type EnvVar, type Gitenvs } from '@/gitenvs/gitenvs.schema'
-import { getNewEnvVarId } from '@/gitenvs/idsGenerator'
+import { type Gitenvs } from '@/gitenvs/gitenvs.schema'
 import { map } from 'lodash-es'
 import { ChevronDown, Import, Link, Plus } from 'lucide-react'
 import { revalidatePath } from 'next/cache'
@@ -65,8 +65,7 @@ export const AddNewEnvVar = async ({
 
                       return superAction(async () => {
                         const envStages = gitenvs.envStages
-                        const newEnVar = {
-                          id: getNewEnvVarId(),
+                        const newEnVar = createEnvVar({
                           key: formData.key,
                           values: Object.fromEntries(
                             await Promise.all(
@@ -88,7 +87,7 @@ export const AddNewEnvVar = async ({
                             ),
                           ),
                           fileIds: [fileId],
-                        } satisfies EnvVar
+                        })
 
                         await saveGitenvs({
                           ...gitenvs,

--- a/@/components/ImportFromFile.tsx
+++ b/@/components/ImportFromFile.tsx
@@ -1,7 +1,6 @@
+import { createEnvVar } from '@/gitenvs/createEnvVar'
 import { getProjectRoot } from '@/gitenvs/getProjectRoot'
 import { getGitenvs } from '@/gitenvs/gitenvs'
-import { type EnvVar } from '@/gitenvs/gitenvs.schema'
-import { getNewEnvVarId } from '@/gitenvs/idsGenerator'
 import { parse } from 'dotenv'
 import { readdir, readFile } from 'fs/promises'
 import { filter, map } from 'lodash-es'
@@ -44,16 +43,11 @@ export const ImportFromFile = async ({ fileId }: { fileId: string }) => {
                   const values = Object.fromEntries(
                     map(gitenvs.envStages, (stage) => [
                       stage.name,
-                      { value, encrypted: false, fileIds: [fileId] },
+                      { value, encrypted: false },
                     ]),
                   )
-                  return {
-                    id: getNewEnvVarId(),
-                    fileIds: [fileId],
-                    key,
-                    values,
-                  }
-                }) satisfies EnvVar[]
+                  return createEnvVar({ fileIds: [fileId], key, values })
+                })
                 return superAction(async () => {
                   streamDialog({
                     title: `Import Env File: ${fileName}`,

--- a/@/components/ImportFromVercel.tsx
+++ b/@/components/ImportFromVercel.tsx
@@ -1,7 +1,6 @@
+import { createEnvVar } from '@/gitenvs/createEnvVar'
 import { getGitenvs } from '@/gitenvs/gitenvs'
-import { type EnvVar } from '@/gitenvs/gitenvs.schema'
 import { getGlobalConfig } from '@/gitenvs/globalConfig'
-import { getNewEnvVarId } from '@/gitenvs/idsGenerator'
 import { Vercel } from '@vercel/sdk'
 import { type Envs } from '@vercel/sdk/dist/commonjs/models/operations/filterprojectenvs'
 import { chunk, filter, groupBy, map, some } from 'lodash-es'
@@ -105,13 +104,12 @@ export const ImportFromVercel = async ({
                       {
                         value: valueInStage,
                         encrypted: false,
-                        fileIds: [fileId],
                       },
                     ]
                   }),
                 )
-                return { id: getNewEnvVarId(), fileIds: [fileId], key, values }
-              }) satisfies EnvVar[]
+                return createEnvVar({ fileIds: [fileId], key, values })
+              })
               return superAction(async () => {
                 streamDialog({
                   title: `Import Env from Vercel`,

--- a/@/components/PasteEnvVars.tsx
+++ b/@/components/PasteEnvVars.tsx
@@ -1,6 +1,6 @@
 'use client'
+import { createEnvVar } from '@/gitenvs/createEnvVar'
 import { type EnvVar, type Gitenvs } from '@/gitenvs/gitenvs.schema'
-import { getNewEnvVarId } from '@/gitenvs/idsGenerator'
 import { usePasteHandler } from '@/hooks/usePasteHandler'
 import { parse } from 'dotenv'
 import { atom, useAtomValue, useSetAtom } from 'jotai'
@@ -34,7 +34,7 @@ export const PasteEnvVars = ({
               { value, encrypted: false },
             ]),
           )
-          return { id: getNewEnvVarId(), fileIds: [fileId], key, values }
+          return createEnvVar({ fileIds: [fileId], key, values })
         }),
       )
     },

--- a/@/components/TableEnvKey.tsx
+++ b/@/components/TableEnvKey.tsx
@@ -1,6 +1,6 @@
+import { createEnvVar } from '@/gitenvs/createEnvVar'
 import { saveGitenvs } from '@/gitenvs/gitenvs'
 import { type EnvVar, type Gitenvs } from '@/gitenvs/gitenvs.schema'
-import { getNewEnvVarId } from '@/gitenvs/idsGenerator'
 import { cloneDeep, filter, flatMap } from 'lodash-es'
 import { ChevronDown, Pencil, Trash, Unlink } from 'lucide-react'
 import { type ReactNode } from 'react'
@@ -119,11 +119,11 @@ export const TableEnvKey = ({
                         (evFileIds) => evFileIds !== fileId,
                       ),
                     }
-                    const oldEnvVarAsNew = {
-                      ...oldEnvVar,
-                      id: getNewEnvVarId(),
+                    const oldEnvVarAsNew = createEnvVar({
+                      key: oldEnvVar.key,
+                      values: oldEnvVar.values,
                       fileIds: [fileId],
-                    }
+                    })
                     return [
                       oldEnvVarAsNew,
                       oldWithoutCurrentFileId,

--- a/@/gitenvs/createEnvVar.ts
+++ b/@/gitenvs/createEnvVar.ts
@@ -1,0 +1,19 @@
+import { type EnvVar } from './gitenvs.schema'
+import { getNewEnvVarId } from './idsGenerator'
+
+export const createEnvVar = ({
+  fileIds,
+  key,
+  values = {},
+}: {
+  fileIds: string[]
+  key: string
+  values?: EnvVar['values']
+}) => {
+  return {
+    id: getNewEnvVarId(),
+    fileIds,
+    key,
+    values,
+  } satisfies EnvVar
+}

--- a/@/gitenvs/upsertEnvVar.ts
+++ b/@/gitenvs/upsertEnvVar.ts
@@ -1,7 +1,7 @@
 import { find } from 'lodash-es'
+import { createEnvVar } from './createEnvVar'
 import { encryptEnvVar } from './encryptEnvVar'
 import { getGitenvs, saveGitenvs } from './gitenvs'
-import { getNewEnvFileId } from './idsGenerator'
 
 export const upsertEnvVarValue = async ({
   fileId,
@@ -33,12 +33,10 @@ export const upsertEnvVarValue = async ({
     (v) => v.fileIds.includes(file.id) && v.key === key,
   )
   if (!envVar) {
-    envVar = {
-      id: getNewEnvFileId(),
+    envVar = createEnvVar({
       fileIds: [file.id],
       key,
-      values: {},
-    }
+    })
     gitenvs.envVars.push(envVar)
   }
 

--- a/lib/cli/set/setCommand.test.ts
+++ b/lib/cli/set/setCommand.test.ts
@@ -1,0 +1,76 @@
+import { GITENVS_DIR_ENV_NAME } from '@/gitenvs/env'
+import { type Gitenvs } from '@/gitenvs/gitenvs.schema'
+import { mkdtemp, readFile, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, expect, test, vi } from 'vitest'
+import { setCommand } from './setCommand'
+
+let testDir: string | undefined
+
+afterEach(async () => {
+  delete process.env[GITENVS_DIR_ENV_NAME]
+  vi.restoreAllMocks()
+
+  if (testDir) {
+    await rm(testDir, { recursive: true, force: true })
+    testDir = undefined
+  }
+})
+
+test('creates new env vars with envVar ids', async () => {
+  testDir = await mkdtemp(join(tmpdir(), 'gitenvs-set-'))
+  process.env[GITENVS_DIR_ENV_NAME] = testDir
+
+  const gitenvs = {
+    version: '2',
+    envStages: [
+      {
+        name: 'development',
+        publicKey: '',
+        encryptedPrivateKey: '',
+      },
+    ],
+    envFiles: [
+      {
+        id: 'envFile_6Gv71d0ZenuC9N39CeGz1c',
+        name: '.env',
+        filePath: '.env',
+        type: 'dotenv',
+      },
+    ],
+    envVars: [],
+  } satisfies Gitenvs
+
+  await writeFile(
+    join(testDir, 'gitenvs.json'),
+    JSON.stringify(gitenvs, null, 2),
+  )
+  vi.spyOn(console, 'log').mockImplementation(() => undefined)
+
+  await setCommand({
+    file: '.env',
+    key: 'API_KEY',
+    value: 'secret',
+    stage: 'development',
+    encrypt: false,
+  })
+
+  const saved = JSON.parse(
+    await readFile(join(testDir, 'gitenvs.json'), 'utf-8'),
+  ) as Gitenvs
+
+  expect(saved.envVars).toHaveLength(1)
+  expect(saved.envVars[0]?.id).toMatch(/^envVar_/)
+  expect(saved.envVars[0]?.id).not.toMatch(/^envFile_/)
+  expect(saved.envVars[0]).toMatchObject({
+    fileIds: ['envFile_6Gv71d0ZenuC9N39CeGz1c'],
+    key: 'API_KEY',
+    values: {
+      development: {
+        value: 'secret',
+        encrypted: false,
+      },
+    },
+  })
+})


### PR DESCRIPTION
This commit replaces the usage of the `getNewEnvVarId` function with the new `createEnvVar` function in multiple components, including AddNewEnvVar, ImportFromFile, ImportFromVercel, PasteEnvVars, TableEnvKey, and upsertEnvVar. This change streamlines the creation of environment variables and enhances code consistency.