### PR TITLE
[chat:codex_3ih7fJyAIZ2L_KBS] fix: quote shell-sensitive dotenv values

### DIFF
--- a/lib/cli/create/getFileContent.test.ts
+++ b/lib/cli/create/getFileContent.test.ts
@@ -270,7 +270,7 @@ test('dotenv: hashtag quoting', async () => {
       envStage: developmentStage,
       passphrase: developmentPassphrase,
     }),
-  ).toBe(`HASHTAG="hello#world"`)
+  ).toBe(`HASHTAG='hello#world'`)
 
   gitenvsToTest = structuredClone(gitenvs)
   gitenvsToTest.envVars = [
@@ -336,7 +336,75 @@ test('dotenv: hashtag quoting', async () => {
       envStage: developmentStage,
       passphrase: developmentPassphrase,
     }),
-  ).rejects.toThrow(/includes both single and double/i)
+  ).rejects.toThrow(/both dotenv-parser compatible and shell-sourceable/i)
+})
+
+test('dotenv: shell-sensitive characters are quoted safely', async () => {
+  let gitenvsToTest = structuredClone(gitenvs)
+  gitenvsToTest.envVars = [
+    {
+      id: 'envVar_kaVu9WJituDFeGEf1u4Aob',
+      fileIds: ['envFile_6Gv71d0ZenuC9N39CeGz1c'],
+      key: 'SHELL_SENSITIVE',
+      values: {
+        development: { value: 'hello world & $PATH `date`', encrypted: false },
+        staging: { value: '', encrypted: false },
+        production: { value: '', encrypted: false },
+      },
+    },
+  ]
+  expect(
+    await getFileContent({
+      gitenvs: gitenvsToTest,
+      envFile: dotEnvFile,
+      envStage: developmentStage,
+      passphrase: developmentPassphrase,
+    }),
+  ).toBe("SHELL_SENSITIVE='hello world & $PATH `date`'")
+
+  gitenvsToTest = structuredClone(gitenvs)
+  gitenvsToTest.envVars = [
+    {
+      id: 'envVar_kaVu9WJituDFeGEf1u4Aob',
+      fileIds: ['envFile_6Gv71d0ZenuC9N39CeGz1c'],
+      key: 'SINGLE_QUOTE',
+      values: {
+        development: { value: "hello 'quoted' world", encrypted: false },
+        staging: { value: '', encrypted: false },
+        production: { value: '', encrypted: false },
+      },
+    },
+  ]
+  expect(
+    await getFileContent({
+      gitenvs: gitenvsToTest,
+      envFile: dotEnvFile,
+      envStage: developmentStage,
+      passphrase: developmentPassphrase,
+    }),
+  ).toBe(`SINGLE_QUOTE="hello 'quoted' world"`)
+
+  gitenvsToTest = structuredClone(gitenvs)
+  gitenvsToTest.envVars = [
+    {
+      id: 'envVar_kaVu9WJituDFeGEf1u4Aob',
+      fileIds: ['envFile_6Gv71d0ZenuC9N39CeGz1c'],
+      key: 'UNREPRESENTABLE',
+      values: {
+        development: { value: "can't keep $PATH literal", encrypted: false },
+        staging: { value: '', encrypted: false },
+        production: { value: '', encrypted: false },
+      },
+    },
+  ]
+  await expect(
+    getFileContent({
+      gitenvs: gitenvsToTest,
+      envFile: dotEnvFile,
+      envStage: developmentStage,
+      passphrase: developmentPassphrase,
+    }),
+  ).rejects.toThrow(/both dotenv-parser compatible and shell-sourceable/i)
 })
 
 test('.ts: quoting', async () => {

--- a/lib/cli/create/getFileContent.ts
+++ b/lib/cli/create/getFileContent.ts
@@ -85,26 +85,25 @@ const resolveEnvVar = async ({
 }
 
 const getDotenvLine = ({ key, value }: { key: string; value: string }) => {
-  const includesCommentCharacter = value.includes('#')
+  const needsShellQuoting = /[\s#"'`$&|;<>(){}!*?\[\]\\]/.test(value)
   const includesDoubleQuote = value.includes('"')
   const includesSingleQuote = value.includes("'")
 
   let wrapWith = ''
 
-  if (includesCommentCharacter) {
-    if (includesSingleQuote && includesDoubleQuote) {
-      throw new Error(
-        `❌ Gitenvs: "${key}" includes both single and double quotes and a comment character. This is not supported and will result in unexpected values.`,
-      )
-    }
-    if (includesDoubleQuote) {
+  if (needsShellQuoting) {
+    if (!includesSingleQuote) {
       wrapWith = "'"
-    } else {
+    } else if (!includesDoubleQuote && !/[`$\\]/.test(value)) {
       wrapWith = '"'
+    } else {
+      throw new Error(
+        `❌ Gitenvs: "${key}" cannot be represented in a dotenv file that is both dotenv-parser compatible and shell-sourceable.`,
+      )
     }
 
     console.log(
-      `⚠️ Gitenvs: wrapping "${key}" with ${wrapWith} quotes because it includes a comment character`,
+      `⚠️ Gitenvs: wrapping "${key}" with ${wrapWith} quotes because it includes shell-sensitive characters`,
     )
   }
 


### PR DESCRIPTION
Chat: https://ai.sodefa.de/chats/codex_3ih7fJyAIZ2L_KBS

## Summary
- quote dotenv values that contain shell-sensitive characters so generated `.env` files can be safely sourced by bash in common cases
- keep simple dotenv output unchanged
- fail with an explicit error when a value cannot be represented as both dotenv-parser compatible and shell-sourceable

## Tests
- `pnpm vitest run lib/cli/create/getFileContent.test.ts`
- `pnpm vitest run`
- shell smoke test for `source` with quoted sample values
