### PR TITLE
feat: add agent-friendly gitenvs CLI setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,26 @@ A UI is automatically opened in your browser. Run through the wizard to set up g
 
 - `npx gitenvs@latest` - opens the UI, if its the first time in this project, the setup wizard will show up automatically
   - if gitenvs is installed as a dev dependency, you just run `gitenvs`
+- `gitenvs setup` – set up gitenvs non-interactively for scripts and AI agents. It creates `gitenvs.json`, writes `gitenvs.passphrases.json`, updates `.gitignore`, and can install/package-wire gitenvs.
+  - useful defaults:
+    ```bash
+    bunx gitenvs setup --yes
+    ```
+  - optional parameters:
+    - `--stages <stages>` – comma-separated stage names. Default: `development,staging,production`
+    - `--file <filePath>` – env file path to configure. Default: `.env`
+    - `--file-name <fileName>` – display label for the env file
+    - `--file-type <fileType>` – `dotenv` or `.ts`. Default: `dotenv`
+    - `--force` – overwrite existing `gitenvs.json` and `gitenvs.passphrases.json`
+    - `--no-gitignore`, `--no-install`, `--no-postinstall`, `--no-scripts` – skip individual project setup steps
 - `gitenvs set` – add or update an env var (encrypted by default). Designed for scripts and AI agents – no passphrase required since encryption uses each stage's public key from `gitenvs.json`.
   - required parameters:
     - `--file <filePath>` – the env file to add the var to, matched against `envFiles[].filePath` in `gitenvs.json` (e.g. `--file .env`)
     - `--key <key>` – the env var key (e.g. `DATABASE_URL`)
-    - `--value <value>` – the value to store
+  - value input: provide exactly one of:
+    - `--value <value>` – the value to store. Convenient, but avoid for sensitive values in automation because argv can be logged.
+    - `--value-env <envName>` – read the value from an environment variable.
+    - `--value-stdin` – read the value from stdin.
   - optional parameters:
     - `--stage <stage>` – limit the change to a single stage. Without it the value is written to **all** stages.
     - `--no-encrypt` – store the value as plaintext. By default the value is encrypted with the stage's public key.
@@ -104,6 +119,14 @@ A UI is automatically opened in your browser. Run through the wizard to set up g
     - `--stage <stage>` (default: development) - the stage to create the env files for (env var > cli param > default)
     - `--passphrase <passphrase>` - the passphrase to use for the stage (cli param > env var)
     - `--passphrasePath <passphrasePath>` - the path to the passphrase file
+- `gitenvs status` – print a secret-safe status summary. Add `--json` for machine-readable output.
+- `gitenvs doctor` – validate the local setup and exit non-zero if it finds issues. Add `--json` for machine-readable output.
+- `gitenvs passphrases validate` – validate `gitenvs.passphrases.json` without printing passphrase values. Add `--json` for machine-readable output.
+- `gitenvs ci env --stage <stage>` – print the CI env var names needed to run `gitenvs create` for a stage without printing any secrets. Add `--json` for machine-readable output.
+
+### Agent and provider integrations
+
+Gitenvs intentionally keeps provider sync out of the core CLI. A company-specific agent or wrapper can read `gitenvs.passphrases.json` and write it to Bitwarden, Vercel, GitHub Actions, or another secret backend. Gitenvs provides the local, portable contract: `gitenvs.json`, `gitenvs.passphrases.json`, `gitenvs set --value-env/--value-stdin`, `gitenvs create`, and secret-safe status/CI metadata commands.
 
 ### Example setup for cloud hosting providers
 

--- a/lib/cli/ci/ciEnvCommand.test.ts
+++ b/lib/cli/ci/ciEnvCommand.test.ts
@@ -1,0 +1,59 @@
+import { GITENVS_DIR_ENV_NAME } from '@/gitenvs/env'
+import { type Gitenvs } from '@/gitenvs/gitenvs.schema'
+import { mkdtemp, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, expect, test, vi } from 'vitest'
+import { ciEnvCommand } from './ciEnvCommand'
+
+let testDir: string | undefined
+
+afterEach(async () => {
+  delete process.env[GITENVS_DIR_ENV_NAME]
+  vi.restoreAllMocks()
+
+  if (testDir) {
+    await rm(testDir, { recursive: true, force: true })
+    testDir = undefined
+  }
+})
+
+test('prints CI metadata without secret values', async () => {
+  testDir = await mkdtemp(join(tmpdir(), 'gitenvs-ci-'))
+  process.env[GITENVS_DIR_ENV_NAME] = testDir
+  const consoleLog = vi
+    .spyOn(console, 'log')
+    .mockImplementation(() => undefined)
+
+  const gitenvs = {
+    version: '2',
+    envStages: [
+      {
+        name: 'production',
+        publicKey: 'public-key',
+        encryptedPrivateKey: 'encrypted-private-key',
+      },
+    ],
+    envFiles: [
+      {
+        id: 'envFile_6Gv71d0ZenuC9N39CeGz1c',
+        name: '.env',
+        filePath: '.env',
+        type: 'dotenv',
+      },
+    ],
+    envVars: [],
+  } satisfies Gitenvs
+
+  await writeFile(join(testDir, 'gitenvs.json'), JSON.stringify(gitenvs))
+
+  await ciEnvCommand({
+    stage: 'production',
+    json: true,
+  })
+
+  const output = consoleLog.mock.calls.map((call) => call.join(' ')).join('\n')
+  expect(output).toContain('GITENVS_PASSPHRASE_PRODUCTION')
+  expect(output).toContain('gitenvs.passphrases.json')
+  expect(output).not.toContain('encrypted-private-key')
+})

--- a/lib/cli/ci/ciEnvCommand.ts
+++ b/lib/cli/ci/ciEnvCommand.ts
@@ -1,0 +1,53 @@
+import { GITENVS_STAGE_ENV_NAME, getPassphraseEnvName } from '@/gitenvs/env'
+import { PASSPHRASE_FILE_NAME } from '@/gitenvs/getPassphrase'
+import { getGitenvs } from '@/gitenvs/gitenvs'
+import { z } from 'zod'
+
+export const ciEnvCommandSchema = z.object({
+  stage: z.string().optional(),
+  json: z.boolean().default(false),
+})
+
+export const ciEnvCommand = async (
+  options: z.infer<typeof ciEnvCommandSchema>,
+) => {
+  const gitenvs = await getGitenvs()
+  const stage = options.stage ?? process.env[GITENVS_STAGE_ENV_NAME]
+
+  if (!stage) {
+    console.error(
+      `❌ Gitenvs: Stage is required. Set --stage <stage> or ${GITENVS_STAGE_ENV_NAME}.`,
+    )
+    process.exit(1)
+  }
+
+  if (!gitenvs.envStages.some((envStage) => envStage.name === stage)) {
+    const available = gitenvs.envStages.map((envStage) => envStage.name)
+    console.error(
+      `❌ Gitenvs: Stage not found: ${stage}. Available: ${
+        available.join(', ') || '(none)'
+      }`,
+    )
+    process.exit(1)
+  }
+
+  const result = {
+    stage,
+    stageEnv: GITENVS_STAGE_ENV_NAME,
+    passphraseEnv: getPassphraseEnvName({ stage }),
+    passphraseFile: PASSPHRASE_FILE_NAME,
+    envFiles: gitenvs.envFiles.map((envFile) => ({
+      name: envFile.name,
+      filePath: envFile.filePath,
+      type: envFile.type,
+    })),
+  }
+
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2))
+    return
+  }
+
+  console.log(`${result.stageEnv}=${result.stage}`)
+  console.log(`${result.passphraseEnv}=<set ${stage} passphrase here>`)
+}

--- a/lib/cli/doctor/doctorCommand.ts
+++ b/lib/cli/doctor/doctorCommand.ts
@@ -1,0 +1,37 @@
+import { collectStatus } from '../status/statusCommand'
+import { z } from 'zod'
+
+export const doctorCommandSchema = z.object({
+  json: z.boolean().default(false),
+})
+
+export const doctorCommand = async (
+  options: z.infer<typeof doctorCommandSchema>,
+) => {
+  const status = await collectStatus()
+
+  if (options.json) {
+    console.log(
+      JSON.stringify(
+        {
+          ok: status.ok,
+          issues: status.issues,
+          status,
+        },
+        null,
+        2,
+      ),
+    )
+  } else if (status.ok) {
+    console.log('✅ Gitenvs: doctor found no issues')
+  } else {
+    console.log('❌ Gitenvs: doctor found issues')
+    for (const issue of status.issues) {
+      console.log(`- ${issue}`)
+    }
+  }
+
+  if (!status.ok) {
+    process.exitCode = 1
+  }
+}

--- a/lib/cli/main.ts
+++ b/lib/cli/main.ts
@@ -13,9 +13,17 @@ import { randomBytes } from 'crypto'
 import { mkdir, readFile, writeFile } from 'fs/promises'
 import { dirname, join } from 'path'
 import { fileURLToPath } from 'url'
+import { ciEnvCommand, ciEnvCommandSchema } from './ci/ciEnvCommand'
 import { createCommand, createCommandSchema } from './create/createCommand'
+import { doctorCommand, doctorCommandSchema } from './doctor/doctorCommand'
 import { getAvailablePort } from './getAvailablePort'
+import {
+  passphrasesValidateCommand,
+  passphrasesValidateCommandSchema,
+} from './passphrases/passphrasesCommand'
 import { setCommand, setCommandSchema } from './set/setCommand'
+import { setupCommand, setupCommandSchema } from './setup/setupCommand'
+import { statusCommand, statusCommandSchema } from './status/statusCommand'
 
 // test node version >= 20
 const [major] = process.versions.node.split('.').map(Number)
@@ -28,7 +36,9 @@ const getGitenvsUiEnvVars = async () => {
   const { basePort, port } = await getAvailablePort(process.env.PORT)
 
   if (port !== basePort) {
-    console.log(`⚠️ Gitenvs: Port ${basePort} is in use, using ${port} instead.`)
+    console.log(
+      `⚠️ Gitenvs: Port ${basePort} is in use, using ${port} instead.`,
+    )
   }
 
   return {
@@ -133,6 +143,35 @@ program
   })
 
 program
+  .command('setup')
+  .description('Sets up gitenvs non-interactively for scripts and agents')
+  .option(
+    '--stages <stages>',
+    'Comma-separated stage names',
+    'development,staging,production',
+  )
+  .option('--file <filePath>', 'Env file path to configure', '.env')
+  .option('--file-name <fileName>', 'Env file label')
+  .option('--file-type <fileType>', 'Env file type: dotenv or .ts', 'dotenv')
+  .option('--force', 'Overwrite gitenvs.json and passphrases')
+  .option('--no-gitignore', 'Do not update .gitignore')
+  .option('--no-install', 'Do not install gitenvs as a dev dependency')
+  .option('--no-postinstall', 'Do not add gitenvs create to postinstall')
+  .option('--no-scripts', 'Do not add scripts.gitenvs')
+  .option('--yes', 'Assume yes for non-interactive setup')
+  .action(async (options) => {
+    const parsed = setupCommandSchema.safeParse(options)
+
+    if (!parsed.success) {
+      console.error('❌ Gitenvs: Invalid options')
+      console.error(parsed.error.message)
+      process.exit(1)
+    }
+
+    await setupCommand(parsed.data)
+  })
+
+program
   .command('set')
   .description('Add or update an env var (encrypted by default)')
   .requiredOption(
@@ -140,7 +179,9 @@ program
     'Path of the env file from gitenvs.json (e.g. .env)',
   )
   .requiredOption('--key <key>', 'Env var key, e.g. DATABASE_URL')
-  .requiredOption('--value <value>', 'Value to store')
+  .option('--value <value>', 'Value to store')
+  .option('--value-env <envName>', 'Read the value from an env var')
+  .option('--value-stdin', 'Read the value from stdin')
   .option('--stage <stage>', 'Limit to a single stage; defaults to all stages')
   .option('--no-encrypt', 'Store the value as plaintext')
   .action(async (options) => {
@@ -155,6 +196,80 @@ program
     }
 
     await setCommand(parsed.data)
+  })
+
+program
+  .command('status')
+  .description('Prints a secret-safe project status')
+  .option('--json', 'Print machine-readable JSON')
+  .action(async (options) => {
+    const parsed = statusCommandSchema.safeParse(options)
+
+    if (!parsed.success) {
+      console.error('❌ Gitenvs: Invalid options')
+      console.error(parsed.error.message)
+      process.exit(1)
+    }
+
+    await statusCommand(parsed.data)
+  })
+
+program
+  .command('doctor')
+  .description('Checks the local gitenvs setup')
+  .option('--json', 'Print machine-readable JSON')
+  .action(async (options) => {
+    const parsed = doctorCommandSchema.safeParse(options)
+
+    if (!parsed.success) {
+      console.error('❌ Gitenvs: Invalid options')
+      console.error(parsed.error.message)
+      process.exit(1)
+    }
+
+    await doctorCommand(parsed.data)
+  })
+
+const passphrases = program
+  .command('passphrases')
+  .description('Works with the local passphrase file')
+
+passphrases
+  .command('validate')
+  .description('Validates gitenvs.passphrases.json without printing secrets')
+  .option('--json', 'Print machine-readable JSON')
+  .action(async (options) => {
+    const parsed = passphrasesValidateCommandSchema.safeParse(options)
+
+    if (!parsed.success) {
+      console.error('❌ Gitenvs: Invalid options')
+      console.error(parsed.error.message)
+      process.exit(1)
+    }
+
+    await passphrasesValidateCommand(parsed.data)
+  })
+
+const ci = program
+  .command('ci')
+  .description('Prints CI metadata without printing secrets')
+
+ci.command('env')
+  .description('Prints env var names needed to run gitenvs create in CI')
+  .option('--stage <stage>', 'Stage to describe')
+  .option('--json', 'Print machine-readable JSON')
+  .action(async (options) => {
+    await checkGitenvsVersion()
+
+    const parsed = ciEnvCommandSchema.safeParse(options)
+
+    if (!parsed.success) {
+      console.error('❌ Gitenvs: Invalid options')
+      console.error(parsed.error.message)
+      process.exit(1)
+    }
+
+    await ciEnvCommand(parsed.data)
   })
 
 // TODO: Should only be visible in dev mode

--- a/lib/cli/passphrases/passphrasesCommand.test.ts
+++ b/lib/cli/passphrases/passphrasesCommand.test.ts
@@ -74,3 +74,46 @@ test('reports legacy configs instead of crashing while validating passphrases', 
   expect(output).not.toContain('very-secret')
   expect(process.exitCode).toBe(1)
 })
+
+test('reports invalid current configs while validating passphrases', async () => {
+  testDir = await mkdtemp(join(tmpdir(), 'gitenvs-passphrases-'))
+  process.env[GITENVS_DIR_ENV_NAME] = testDir
+  const consoleLog = vi
+    .spyOn(console, 'log')
+    .mockImplementation(() => undefined)
+
+  const malformedGitenvs = {
+    version: '2',
+    envStages: [
+      {
+        name: 'production',
+        publicKey: 'public-key',
+        encryptedPrivateKey: 'encrypted-private-key',
+      },
+    ],
+    envVars: [],
+  }
+  const passphrases = [
+    {
+      stageName: 'production',
+      passphrase: 'very-secret',
+    },
+  ] satisfies Passphrase[]
+
+  await writeFile(
+    join(testDir, 'gitenvs.json'),
+    JSON.stringify(malformedGitenvs),
+  )
+  await writeFile(
+    join(testDir, PASSPHRASE_FILE_NAME),
+    JSON.stringify(passphrases),
+  )
+  await writeFile(join(testDir, '.gitignore'), PASSPHRASE_FILE_NAME)
+
+  await passphrasesValidateCommand({ json: true })
+
+  const output = consoleLog.mock.calls.map((call) => call.join(' ')).join('\n')
+  expect(output).toContain('gitenvs.json is invalid')
+  expect(output).not.toContain('very-secret')
+  expect(process.exitCode).toBe(1)
+})

--- a/lib/cli/passphrases/passphrasesCommand.test.ts
+++ b/lib/cli/passphrases/passphrasesCommand.test.ts
@@ -1,0 +1,76 @@
+import { GITENVS_DIR_ENV_NAME } from '@/gitenvs/env'
+import { type Passphrase } from '@/gitenvs/gitenvs.schema'
+import { PASSPHRASE_FILE_NAME } from '@/gitenvs/getPassphrase'
+import { mkdtemp, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, expect, test, vi } from 'vitest'
+import { passphrasesValidateCommand } from './passphrasesCommand'
+
+let testDir: string | undefined
+
+afterEach(async () => {
+  delete process.env[GITENVS_DIR_ENV_NAME]
+  process.exitCode = undefined
+  vi.restoreAllMocks()
+
+  if (testDir) {
+    await rm(testDir, { recursive: true, force: true })
+    testDir = undefined
+  }
+})
+
+test('reports legacy configs instead of crashing while validating passphrases', async () => {
+  testDir = await mkdtemp(join(tmpdir(), 'gitenvs-passphrases-'))
+  process.env[GITENVS_DIR_ENV_NAME] = testDir
+  const consoleLog = vi
+    .spyOn(console, 'log')
+    .mockImplementation(() => undefined)
+
+  const legacyGitenvs = {
+    version: '1',
+    envStages: [
+      {
+        name: 'production',
+        publicKey: 'public-key',
+        encryptedPrivateKey: 'encrypted-private-key',
+      },
+    ],
+    envFiles: [
+      {
+        id: 'envFile_6Gv71d0ZenuC9N39CeGz1c',
+        name: '.env',
+        filePath: '.env',
+        type: 'dotenv',
+      },
+    ],
+    envVars: [
+      {
+        id: 'envVar_6Gv71d0ZenuC9N39CeGz1c',
+        fileId: 'envFile_6Gv71d0ZenuC9N39CeGz1c',
+        key: 'DATABASE_URL',
+        values: {},
+      },
+    ],
+  }
+  const passphrases = [
+    {
+      stageName: 'production',
+      passphrase: 'very-secret',
+    },
+  ] satisfies Passphrase[]
+
+  await writeFile(join(testDir, 'gitenvs.json'), JSON.stringify(legacyGitenvs))
+  await writeFile(
+    join(testDir, PASSPHRASE_FILE_NAME),
+    JSON.stringify(passphrases),
+  )
+  await writeFile(join(testDir, '.gitignore'), PASSPHRASE_FILE_NAME)
+
+  await passphrasesValidateCommand({ json: true })
+
+  const output = consoleLog.mock.calls.map((call) => call.join(' ')).join('\n')
+  expect(output).toContain('gitenvs.json is not on the latest version')
+  expect(output).not.toContain('very-secret')
+  expect(process.exitCode).toBe(1)
+})

--- a/lib/cli/passphrases/passphrasesCommand.ts
+++ b/lib/cli/passphrases/passphrasesCommand.ts
@@ -1,0 +1,45 @@
+import { collectStatus } from '../status/statusCommand'
+import { z } from 'zod'
+
+export const passphrasesValidateCommandSchema = z.object({
+  json: z.boolean().default(false),
+})
+
+export const passphrasesValidateCommand = async (
+  options: z.infer<typeof passphrasesValidateCommandSchema>,
+) => {
+  const status = await collectStatus()
+  const issues = [
+    !status.passphrases.exists ? 'passphrase file not found' : null,
+    status.passphrases.exists && !status.passphrases.valid
+      ? 'passphrase file is invalid'
+      : null,
+    ...status.passphrases.missingStages.map(
+      (stageName) => `missing passphrase for stage ${stageName}`,
+    ),
+  ].filter((issue): issue is string => issue !== null)
+
+  const result = {
+    ok: issues.length === 0,
+    path: status.passphrases.path,
+    stages: status.passphrases.stages,
+    missingStages: status.passphrases.missingStages,
+    extraStages: status.passphrases.extraStages,
+    issues,
+  }
+
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2))
+  } else if (result.ok) {
+    console.log('✅ Gitenvs: passphrase file is valid')
+  } else {
+    console.log('❌ Gitenvs: passphrase file is invalid')
+    for (const issue of result.issues) {
+      console.log(`- ${issue}`)
+    }
+  }
+
+  if (!result.ok) {
+    process.exitCode = 1
+  }
+}

--- a/lib/cli/passphrases/passphrasesCommand.ts
+++ b/lib/cli/passphrases/passphrasesCommand.ts
@@ -9,10 +9,13 @@ export const passphrasesValidateCommand = async (
   options: z.infer<typeof passphrasesValidateCommandSchema>,
 ) => {
   const status = await collectStatus()
+  const configIssues = status.issues.filter(
+    (issue) =>
+      issue === 'gitenvs.json is invalid' ||
+      issue === 'gitenvs.json is not on the latest version',
+  )
   const issues = [
-    status.gitenvs.latest === false
-      ? 'gitenvs.json is not on the latest version'
-      : null,
+    ...configIssues,
     !status.passphrases.exists ? 'passphrase file not found' : null,
     status.passphrases.exists && !status.passphrases.valid
       ? 'passphrase file is invalid'

--- a/lib/cli/passphrases/passphrasesCommand.ts
+++ b/lib/cli/passphrases/passphrasesCommand.ts
@@ -10,6 +10,9 @@ export const passphrasesValidateCommand = async (
 ) => {
   const status = await collectStatus()
   const issues = [
+    status.gitenvs.latest === false
+      ? 'gitenvs.json is not on the latest version'
+      : null,
     !status.passphrases.exists ? 'passphrase file not found' : null,
     status.passphrases.exists && !status.passphrases.valid
       ? 'passphrase file is invalid'

--- a/lib/cli/set/setCommand.test.ts
+++ b/lib/cli/set/setCommand.test.ts
@@ -10,6 +10,7 @@ let testDir: string | undefined
 
 afterEach(async () => {
   delete process.env[GITENVS_DIR_ENV_NAME]
+  delete process.env.SECRET_SOURCE
   vi.restoreAllMocks()
 
   if (testDir) {
@@ -52,6 +53,7 @@ test('creates new env vars with envVar ids', async () => {
     file: '.env',
     key: 'API_KEY',
     value: 'secret',
+    valueStdin: false,
     stage: 'development',
     encrypt: false,
   })
@@ -69,6 +71,61 @@ test('creates new env vars with envVar ids', async () => {
     values: {
       development: {
         value: 'secret',
+        encrypted: false,
+      },
+    },
+  })
+})
+
+test('reads values from env vars without exposing them in argv', async () => {
+  testDir = await mkdtemp(join(tmpdir(), 'gitenvs-set-'))
+  process.env[GITENVS_DIR_ENV_NAME] = testDir
+  process.env.SECRET_SOURCE = 'secret-from-env'
+
+  const gitenvs = {
+    version: '2',
+    envStages: [
+      {
+        name: 'development',
+        publicKey: '',
+        encryptedPrivateKey: '',
+      },
+    ],
+    envFiles: [
+      {
+        id: 'envFile_6Gv71d0ZenuC9N39CeGz1c',
+        name: '.env',
+        filePath: '.env',
+        type: 'dotenv',
+      },
+    ],
+    envVars: [],
+  } satisfies Gitenvs
+
+  await writeFile(
+    join(testDir, 'gitenvs.json'),
+    JSON.stringify(gitenvs, null, 2),
+  )
+  vi.spyOn(console, 'log').mockImplementation(() => undefined)
+
+  await setCommand({
+    file: '.env',
+    key: 'API_KEY',
+    valueEnv: 'SECRET_SOURCE',
+    valueStdin: false,
+    stage: 'development',
+    encrypt: false,
+  })
+
+  const saved = JSON.parse(
+    await readFile(join(testDir, 'gitenvs.json'), 'utf-8'),
+  ) as Gitenvs
+
+  expect(saved.envVars[0]).toMatchObject({
+    key: 'API_KEY',
+    values: {
+      development: {
+        value: 'secret-from-env',
         encrypted: false,
       },
     },

--- a/lib/cli/set/setCommand.ts
+++ b/lib/cli/set/setCommand.ts
@@ -6,14 +6,57 @@ import { z } from 'zod'
 export const setCommandSchema = z.object({
   file: z.string().min(1, '--file is required'),
   key: z.string().min(1, '--key is required'),
-  value: z.string(),
+  value: z.string().optional(),
+  valueEnv: z.string().optional(),
+  valueStdin: z.boolean().default(false),
   stage: z.string().optional(),
   encrypt: z.boolean().default(true),
 })
 
-export const setCommand = async (
-  options: z.infer<typeof setCommandSchema>,
-) => {
+const stripFinalNewline = (value: string) => value.replace(/\r?\n$/, '')
+
+const readStdin = async () => {
+  let value = ''
+  process.stdin.setEncoding('utf-8')
+
+  for await (const chunk of process.stdin) {
+    value += chunk
+  }
+
+  return stripFinalNewline(value)
+}
+
+const getValue = async (options: z.infer<typeof setCommandSchema>) => {
+  const inputMethods = [
+    options.value !== undefined,
+    options.valueEnv !== undefined,
+    options.valueStdin,
+  ].filter(Boolean)
+
+  if (inputMethods.length !== 1) {
+    console.error(
+      '❌ Gitenvs: Provide exactly one of --value, --value-env, or --value-stdin.',
+    )
+    process.exit(1)
+  }
+
+  if (options.value !== undefined) {
+    return options.value
+  }
+
+  if (options.valueEnv !== undefined) {
+    if (!(options.valueEnv in process.env)) {
+      console.error(`❌ Gitenvs: Env var not found: ${options.valueEnv}`)
+      process.exit(1)
+    }
+
+    return process.env[options.valueEnv] ?? ''
+  }
+
+  return readStdin()
+}
+
+export const setCommand = async (options: z.infer<typeof setCommandSchema>) => {
   const gitenvsExists = await getIsGitenvsExisting()
   if (!gitenvsExists) {
     console.error('❌ Gitenvs: gitenvs.json not found')
@@ -29,6 +72,7 @@ export const setCommand = async (
   }
 
   const gitenvs = await getGitenvs()
+  const value = await getValue(options)
 
   const envFile = gitenvs.envFiles.find((f) => f.filePath === options.file)
   if (!envFile) {
@@ -56,7 +100,7 @@ export const setCommand = async (
       fileId: envFile.id,
       stage: stage.name,
       key: options.key,
-      value: options.value,
+      value,
       encrypt: options.encrypt,
     })
 

--- a/lib/cli/setup/setupCommand.test.ts
+++ b/lib/cli/setup/setupCommand.test.ts
@@ -1,0 +1,68 @@
+import { GITENVS_DIR_ENV_NAME } from '@/gitenvs/env'
+import { type Gitenvs, type Passphrase } from '@/gitenvs/gitenvs.schema'
+import { PASSPHRASE_FILE_NAME } from '@/gitenvs/getPassphrase'
+import { mkdtemp, readFile, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, expect, test, vi } from 'vitest'
+import { setupCommand } from './setupCommand'
+
+let testDir: string | undefined
+
+afterEach(async () => {
+  delete process.env[GITENVS_DIR_ENV_NAME]
+  vi.restoreAllMocks()
+
+  if (testDir) {
+    await rm(testDir, { recursive: true, force: true })
+    testDir = undefined
+  }
+})
+
+test('sets up gitenvs files without provider-specific integrations', async () => {
+  testDir = await mkdtemp(join(tmpdir(), 'gitenvs-setup-'))
+  process.env[GITENVS_DIR_ENV_NAME] = testDir
+  vi.spyOn(console, 'log').mockImplementation(() => undefined)
+
+  await setupCommand({
+    stages: 'development,production',
+    file: '.env.local',
+    fileName: 'Local env',
+    fileType: 'dotenv',
+    force: false,
+    gitignore: true,
+    install: false,
+    postinstall: false,
+    scripts: false,
+    yes: true,
+  })
+
+  const gitenvs = JSON.parse(
+    await readFile(join(testDir, 'gitenvs.json'), 'utf-8'),
+  ) as Gitenvs
+  const passphrases = JSON.parse(
+    await readFile(join(testDir, PASSPHRASE_FILE_NAME), 'utf-8'),
+  ) as Passphrase[]
+  const gitignore = await readFile(join(testDir, '.gitignore'), 'utf-8')
+
+  expect(gitenvs.envStages.map((stage) => stage.name)).toEqual([
+    'development',
+    'production',
+  ])
+  for (const passphrase of passphrases) {
+    expect(JSON.stringify(gitenvs)).not.toContain(passphrase.passphrase)
+  }
+  expect(gitenvs.envFiles).toMatchObject([
+    {
+      name: 'Local env',
+      filePath: '.env.local',
+      type: 'dotenv',
+    },
+  ])
+  expect(passphrases).toHaveLength(2)
+  expect(passphrases.map((passphrase) => passphrase.stageName)).toEqual([
+    'development',
+    'production',
+  ])
+  expect(gitignore).toContain(PASSPHRASE_FILE_NAME)
+})

--- a/lib/cli/setup/setupCommand.ts
+++ b/lib/cli/setup/setupCommand.ts
@@ -1,0 +1,178 @@
+import { createKeys } from '@/gitenvs/createKeys'
+import { getCwd } from '@/gitenvs/getCwd'
+import { getNewEnvFileId } from '@/gitenvs/idsGenerator'
+import { getIsGitenvsInGitIgnore, updateGitIgnore } from '@/gitenvs/gitignore'
+import { checkGitenvsJsonExists, saveGitenvs } from '@/gitenvs/gitenvs'
+import {
+  EnvFileType,
+  type Gitenvs,
+  type Passphrase,
+} from '@/gitenvs/gitenvs.schema'
+import { getProjectRoot } from '@/gitenvs/getProjectRoot'
+import { PASSPHRASE_FILE_NAME } from '@/gitenvs/getPassphrase'
+import { getIsGitenvsInstalled, installGitenvs } from '@/gitenvs/installGitenvs'
+import { addToScripts, getIsAddedToScripts } from '@/gitenvs/packageJsonScripts'
+import {
+  getIsPostInstallScriptExisting,
+  updatePostInstall,
+} from '@/gitenvs/postinstall'
+import { existsSync } from 'fs'
+import { writeFile } from 'fs/promises'
+import { join } from 'path'
+import { z } from 'zod'
+
+export const setupCommandSchema = z.object({
+  stages: z.string().default('development,staging,production'),
+  file: z.string().min(1).default('.env'),
+  fileName: z.string().optional(),
+  fileType: EnvFileType.default('dotenv'),
+  force: z.boolean().default(false),
+  gitignore: z.boolean().default(true),
+  install: z.boolean().default(true),
+  postinstall: z.boolean().default(true),
+  scripts: z.boolean().default(true),
+  yes: z.boolean().default(false),
+})
+
+const exitWithError = (message: string): never => {
+  console.error(`❌ Gitenvs: ${message}`)
+  process.exit(1)
+}
+
+const parseStageNames = (stages: string) => {
+  const stageNames = stages
+    .split(',')
+    .map((stage) => stage.trim())
+    .filter(Boolean)
+
+  if (stageNames.length === 0) {
+    exitWithError('At least one stage is required.')
+  }
+
+  const uniqueStageNames = new Set(stageNames)
+  if (uniqueStageNames.size !== stageNames.length) {
+    exitWithError('Stage names must be unique.')
+  }
+
+  return stageNames
+}
+
+const createInitialGitenvs = async ({
+  stageNames,
+  file,
+  fileName,
+  fileType,
+}: {
+  stageNames: string[]
+  file: string
+  fileName?: string
+  fileType: z.infer<typeof EnvFileType>
+}) => {
+  const stages = await Promise.all(
+    stageNames.map(async (stageName) => {
+      const keys = await createKeys()
+      return {
+        name: stageName,
+        ...keys,
+      }
+    }),
+  )
+
+  const gitenvs = {
+    version: '2',
+    envStages: stages.map(({ passphrase: _passphrase, ...stage }) => stage),
+    envFiles: [
+      {
+        id: getNewEnvFileId(),
+        name: fileName ?? file,
+        filePath: file,
+        type: fileType,
+      },
+    ],
+    envVars: [],
+  } satisfies Gitenvs
+
+  const passphrases = stages.map((stage) => ({
+    stageName: stage.name,
+    passphrase: stage.passphrase,
+  })) satisfies Passphrase[]
+
+  await saveGitenvs(gitenvs)
+  await writeFile(
+    join(getCwd(), PASSPHRASE_FILE_NAME),
+    JSON.stringify(passphrases, null, 2),
+    'utf-8',
+  )
+
+  console.log('✅ Gitenvs: Created gitenvs.json')
+  console.log(`✅ Gitenvs: Created ${PASSPHRASE_FILE_NAME}`)
+}
+
+export const setupCommand = async (
+  options: z.infer<typeof setupCommandSchema>,
+) => {
+  const stageNames = parseStageNames(options.stages)
+  const passphrasePath = join(getCwd(), PASSPHRASE_FILE_NAME)
+  const gitenvsExists = checkGitenvsJsonExists()
+
+  if (!gitenvsExists || options.force) {
+    if (existsSync(passphrasePath) && !options.force && !gitenvsExists) {
+      exitWithError(
+        `${PASSPHRASE_FILE_NAME} already exists. Pass --force to overwrite it.`,
+      )
+    }
+
+    await createInitialGitenvs({
+      stageNames,
+      file: options.file,
+      fileName: options.fileName,
+      fileType: options.fileType,
+    })
+  } else {
+    console.log('✅ Gitenvs: gitenvs.json already exists, keeping it')
+  }
+
+  if (options.gitignore) {
+    if (!(await getIsGitenvsInGitIgnore())) {
+      await updateGitIgnore()
+      console.log(`✅ Gitenvs: Added ${PASSPHRASE_FILE_NAME} to .gitignore`)
+    } else {
+      console.log(`✅ Gitenvs: ${PASSPHRASE_FILE_NAME} is already ignored`)
+    }
+  }
+
+  const { foundPackageJson } = await getProjectRoot()
+  if (!foundPackageJson) {
+    if (options.install || options.postinstall || options.scripts) {
+      console.log('⚠️ Gitenvs: No package.json found, skipped package setup')
+    }
+    return
+  }
+
+  if (options.install) {
+    if (!(await getIsGitenvsInstalled())) {
+      await installGitenvs()
+      console.log('✅ Gitenvs: Installed gitenvs as a dev dependency')
+    } else {
+      console.log('✅ Gitenvs: gitenvs is already installed')
+    }
+  }
+
+  if (options.postinstall) {
+    if (!(await getIsPostInstallScriptExisting())) {
+      await updatePostInstall()
+      console.log('✅ Gitenvs: Added postinstall script')
+    } else {
+      console.log('✅ Gitenvs: postinstall already runs gitenvs create')
+    }
+  }
+
+  if (options.scripts) {
+    if (!(await getIsAddedToScripts())) {
+      await addToScripts()
+      console.log('✅ Gitenvs: Added package script')
+    } else {
+      console.log('✅ Gitenvs: package script already exists')
+    }
+  }
+}

--- a/lib/cli/status/statusCommand.test.ts
+++ b/lib/cli/status/statusCommand.test.ts
@@ -1,0 +1,66 @@
+import { GITENVS_DIR_ENV_NAME } from '@/gitenvs/env'
+import { type Gitenvs, type Passphrase } from '@/gitenvs/gitenvs.schema'
+import { PASSPHRASE_FILE_NAME } from '@/gitenvs/getPassphrase'
+import { mkdtemp, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, expect, test } from 'vitest'
+import { collectStatus } from './statusCommand'
+
+let testDir: string | undefined
+
+afterEach(async () => {
+  delete process.env[GITENVS_DIR_ENV_NAME]
+
+  if (testDir) {
+    await rm(testDir, { recursive: true, force: true })
+    testDir = undefined
+  }
+})
+
+test('collects secret-safe status metadata', async () => {
+  testDir = await mkdtemp(join(tmpdir(), 'gitenvs-status-'))
+  process.env[GITENVS_DIR_ENV_NAME] = testDir
+
+  const gitenvs = {
+    version: '2',
+    envStages: [
+      {
+        name: 'production',
+        publicKey: 'public-key',
+        encryptedPrivateKey: 'encrypted-private-key',
+      },
+    ],
+    envFiles: [
+      {
+        id: 'envFile_6Gv71d0ZenuC9N39CeGz1c',
+        name: '.env',
+        filePath: '.env',
+        type: 'dotenv',
+      },
+    ],
+    envVars: [],
+  } satisfies Gitenvs
+  const passphrases = [
+    {
+      stageName: 'production',
+      passphrase: 'very-secret',
+    },
+  ] satisfies Passphrase[]
+
+  await writeFile(join(testDir, 'gitenvs.json'), JSON.stringify(gitenvs))
+  await writeFile(
+    join(testDir, PASSPHRASE_FILE_NAME),
+    JSON.stringify(passphrases),
+  )
+  await writeFile(join(testDir, '.gitignore'), PASSPHRASE_FILE_NAME)
+
+  const status = await collectStatus()
+
+  expect(status.ok).toBe(true)
+  expect(status.gitenvs.stages).toEqual(['production'])
+  expect(status.ci.passphraseEnvByStage.production).toBe(
+    'GITENVS_PASSPHRASE_PRODUCTION',
+  )
+  expect(JSON.stringify(status)).not.toContain('very-secret')
+})

--- a/lib/cli/status/statusCommand.test.ts
+++ b/lib/cli/status/statusCommand.test.ts
@@ -64,3 +64,57 @@ test('collects secret-safe status metadata', async () => {
   )
   expect(JSON.stringify(status)).not.toContain('very-secret')
 })
+
+test('reports legacy configs without parsing them as current configs', async () => {
+  testDir = await mkdtemp(join(tmpdir(), 'gitenvs-status-'))
+  process.env[GITENVS_DIR_ENV_NAME] = testDir
+
+  const legacyGitenvs = {
+    version: '1',
+    envStages: [
+      {
+        name: 'production',
+        publicKey: 'public-key',
+        encryptedPrivateKey: 'encrypted-private-key',
+      },
+    ],
+    envFiles: [
+      {
+        id: 'envFile_6Gv71d0ZenuC9N39CeGz1c',
+        name: '.env',
+        filePath: '.env',
+        type: 'dotenv',
+      },
+    ],
+    envVars: [
+      {
+        id: 'envVar_6Gv71d0ZenuC9N39CeGz1c',
+        fileId: 'envFile_6Gv71d0ZenuC9N39CeGz1c',
+        key: 'DATABASE_URL',
+        values: {},
+      },
+    ],
+  }
+  const passphrases = [
+    {
+      stageName: 'production',
+      passphrase: 'very-secret',
+    },
+  ] satisfies Passphrase[]
+
+  await writeFile(join(testDir, 'gitenvs.json'), JSON.stringify(legacyGitenvs))
+  await writeFile(
+    join(testDir, PASSPHRASE_FILE_NAME),
+    JSON.stringify(passphrases),
+  )
+  await writeFile(join(testDir, '.gitignore'), PASSPHRASE_FILE_NAME)
+
+  const status = await collectStatus()
+
+  expect(status.ok).toBe(false)
+  expect(status.gitenvs.version).toBe(1)
+  expect(status.gitenvs.latest).toBe(false)
+  expect(status.gitenvs.stages).toEqual(['production'])
+  expect(status.issues).toContain('gitenvs.json is not on the latest version')
+  expect(JSON.stringify(status)).not.toContain('very-secret')
+})

--- a/lib/cli/status/statusCommand.test.ts
+++ b/lib/cli/status/statusCommand.test.ts
@@ -118,3 +118,46 @@ test('reports legacy configs without parsing them as current configs', async () 
   expect(status.issues).toContain('gitenvs.json is not on the latest version')
   expect(JSON.stringify(status)).not.toContain('very-secret')
 })
+
+test('reports invalid current configs instead of crashing', async () => {
+  testDir = await mkdtemp(join(tmpdir(), 'gitenvs-status-'))
+  process.env[GITENVS_DIR_ENV_NAME] = testDir
+
+  const malformedGitenvs = {
+    version: '2',
+    envStages: [
+      {
+        name: 'production',
+        publicKey: 'public-key',
+        encryptedPrivateKey: 'encrypted-private-key',
+      },
+    ],
+    envVars: [],
+  }
+  const passphrases = [
+    {
+      stageName: 'production',
+      passphrase: 'very-secret',
+    },
+  ] satisfies Passphrase[]
+
+  await writeFile(
+    join(testDir, 'gitenvs.json'),
+    JSON.stringify(malformedGitenvs),
+  )
+  await writeFile(
+    join(testDir, PASSPHRASE_FILE_NAME),
+    JSON.stringify(passphrases),
+  )
+  await writeFile(join(testDir, '.gitignore'), PASSPHRASE_FILE_NAME)
+
+  const status = await collectStatus()
+
+  expect(status.ok).toBe(false)
+  expect(status.gitenvs.version).toBe(2)
+  expect(status.gitenvs.latest).toBe(true)
+  expect(status.gitenvs.stages).toEqual([])
+  expect(status.gitenvs.envFiles).toEqual([])
+  expect(status.issues).toContain('gitenvs.json is invalid')
+  expect(JSON.stringify(status)).not.toContain('very-secret')
+})

--- a/lib/cli/status/statusCommand.ts
+++ b/lib/cli/status/statusCommand.ts
@@ -2,12 +2,8 @@ import {
   getIsGitenvsInGitIgnore,
   getIsGitignoreExisting,
 } from '@/gitenvs/gitignore'
-import {
-  checkGitenvsJsonExists,
-  getGitenvs,
-  getGitenvsVersion,
-  latestGitenvsVersion,
-} from '@/gitenvs/gitenvs'
+import { checkGitenvsJsonExists, latestGitenvsVersion } from '@/gitenvs/gitenvs'
+import { Gitenvs } from '@/gitenvs/gitenvs.schema'
 import { GITENVS_STAGE_ENV_NAME, getPassphraseEnvName } from '@/gitenvs/env'
 import { getCwd } from '@/gitenvs/getCwd'
 import { PASSPHRASE_FILE_NAME } from '@/gitenvs/getPassphrase'
@@ -41,27 +37,99 @@ const statusGitenvsSchema = z.object({
   ),
 })
 
+const gitenvsVersionSchema = z.object({
+  version: z.string(),
+})
+
 export const statusCommandSchema = z.object({
   json: z.boolean().default(false),
 })
 
 export type GitenvsStatus = Awaited<ReturnType<typeof collectStatus>>
 
+const readGitenvsStatus = async ({
+  cwd,
+  exists,
+}: {
+  cwd: string
+  exists: boolean
+}) => {
+  if (!exists) {
+    return {
+      version: null,
+      latest: null,
+      gitenvs: null,
+      invalid: false,
+    }
+  }
+
+  const content = await readFile(join(cwd, 'gitenvs.json'), 'utf-8').catch(
+    () => null,
+  )
+  if (content === null) {
+    return {
+      version: null,
+      latest: null,
+      gitenvs: null,
+      invalid: true,
+    }
+  }
+
+  let json: unknown
+  try {
+    json = JSON.parse(content)
+  } catch {
+    return {
+      version: null,
+      latest: null,
+      gitenvs: null,
+      invalid: true,
+    }
+  }
+
+  const versionParsed = gitenvsVersionSchema.safeParse(json)
+  if (!versionParsed.success) {
+    return {
+      version: null,
+      latest: null,
+      gitenvs: null,
+      invalid: true,
+    }
+  }
+
+  const version = parseInt(versionParsed.data.version)
+  const latest = version === latestGitenvsVersion
+
+  if (latest) {
+    const parsed = Gitenvs.safeParse(json)
+    return {
+      version,
+      latest,
+      gitenvs: parsed.success ? parsed.data : null,
+      invalid: !parsed.success,
+    }
+  }
+
+  const parsed = statusGitenvsSchema.safeParse(json)
+  return {
+    version,
+    latest,
+    gitenvs: parsed.success ? parsed.data : null,
+    invalid: false,
+  }
+}
+
 export const collectStatus = async () => {
   const cwd = getCwd()
   const passphrasePath = join(cwd, PASSPHRASE_FILE_NAME)
   const gitenvsExists = checkGitenvsJsonExists()
 
-  const version = gitenvsExists ? await getGitenvsVersion() : null
-  const latest = gitenvsExists ? version === latestGitenvsVersion : null
-  const currentGitenvs = gitenvsExists && latest ? await getGitenvs() : null
-  const statusGitenvs =
-    gitenvsExists && !latest
-      ? await readFile(join(cwd, 'gitenvs.json'), 'utf-8')
-          .then((content) => statusGitenvsSchema.safeParse(JSON.parse(content)))
-          .then((parsed) => (parsed.success ? parsed.data : null))
-          .catch(() => null)
-      : currentGitenvs
+  const {
+    version,
+    latest,
+    gitenvs: statusGitenvs,
+    invalid: gitenvsInvalid,
+  } = await readGitenvsStatus({ cwd, exists: gitenvsExists })
 
   const passphraseFile = await readFile(passphrasePath, 'utf-8')
     .then((content) => {
@@ -110,6 +178,7 @@ export const collectStatus = async () => {
 
   const issues = [
     !gitenvsExists ? 'gitenvs.json not found' : null,
+    gitenvsInvalid ? 'gitenvs.json is invalid' : null,
     latest === false ? 'gitenvs.json is not on the latest version' : null,
     gitenvsExists && !passphraseFile.exists
       ? `${PASSPHRASE_FILE_NAME} not found`

--- a/lib/cli/status/statusCommand.ts
+++ b/lib/cli/status/statusCommand.ts
@@ -1,0 +1,184 @@
+import {
+  getIsGitenvsInGitIgnore,
+  getIsGitignoreExisting,
+} from '@/gitenvs/gitignore'
+import {
+  checkGitenvsJsonExists,
+  getGitenvs,
+  getGitenvsVersion,
+  getIsLatestGitenvsVersion,
+} from '@/gitenvs/gitenvs'
+import { GITENVS_STAGE_ENV_NAME, getPassphraseEnvName } from '@/gitenvs/env'
+import { getCwd } from '@/gitenvs/getCwd'
+import { PASSPHRASE_FILE_NAME } from '@/gitenvs/getPassphrase'
+import { getProjectRoot } from '@/gitenvs/getProjectRoot'
+import { getIsGitenvsInstalled } from '@/gitenvs/installGitenvs'
+import { getIsAddedToScripts } from '@/gitenvs/packageJsonScripts'
+import { getIsPostInstallScriptExisting } from '@/gitenvs/postinstall'
+import { readFile } from 'fs/promises'
+import { join } from 'path'
+import { z } from 'zod'
+
+const passphraseFileSchema = z.array(
+  z.object({
+    stageName: z.string(),
+    passphrase: z.string(),
+  }),
+)
+
+export const statusCommandSchema = z.object({
+  json: z.boolean().default(false),
+})
+
+export type GitenvsStatus = Awaited<ReturnType<typeof collectStatus>>
+
+export const collectStatus = async () => {
+  const cwd = getCwd()
+  const passphrasePath = join(cwd, PASSPHRASE_FILE_NAME)
+  const gitenvsExists = checkGitenvsJsonExists()
+
+  const gitenvs = gitenvsExists ? await getGitenvs() : null
+  const version = gitenvsExists ? await getGitenvsVersion() : null
+  const latest = gitenvsExists ? await getIsLatestGitenvsVersion() : null
+
+  const passphraseFile = await readFile(passphrasePath, 'utf-8')
+    .then((content) => {
+      const parsed = passphraseFileSchema.safeParse(JSON.parse(content))
+      return {
+        exists: true,
+        valid: parsed.success,
+        stages: parsed.success
+          ? parsed.data.map((passphrase) => passphrase.stageName)
+          : [],
+      }
+    })
+    .catch(() => ({
+      exists: false,
+      valid: false,
+      stages: [] as string[],
+    }))
+
+  const configuredStages = gitenvs?.envStages.map((stage) => stage.name) ?? []
+  const missingPassphrases = configuredStages.filter(
+    (stageName) => !passphraseFile.stages.includes(stageName),
+  )
+  const extraPassphrases = passphraseFile.stages.filter(
+    (stageName) => !configuredStages.includes(stageName),
+  )
+  const { foundPackageJson } = await getProjectRoot()
+  const packageJson = foundPackageJson
+    ? {
+        found: true,
+        hasGitenvsDependency: await getIsGitenvsInstalled(),
+        hasPostinstall: await getIsPostInstallScriptExisting(),
+        hasScript: await getIsAddedToScripts(),
+      }
+    : {
+        found: false,
+        hasGitenvsDependency: null,
+        hasPostinstall: null,
+        hasScript: null,
+      }
+
+  const gitignore = {
+    exists: await getIsGitignoreExisting(),
+    includesPassphraseFile: await getIsGitenvsInGitIgnore(),
+  }
+
+  const issues = [
+    !gitenvsExists ? 'gitenvs.json not found' : null,
+    latest === false ? 'gitenvs.json is not on the latest version' : null,
+    gitenvsExists && !passphraseFile.exists
+      ? `${PASSPHRASE_FILE_NAME} not found`
+      : null,
+    passphraseFile.exists && !passphraseFile.valid
+      ? `${PASSPHRASE_FILE_NAME} is invalid`
+      : null,
+    passphraseFile.exists && !gitignore.includesPassphraseFile
+      ? `${PASSPHRASE_FILE_NAME} is not ignored`
+      : null,
+    ...missingPassphrases.map(
+      (stageName) => `missing passphrase for stage ${stageName}`,
+    ),
+  ].filter((issue): issue is string => issue !== null)
+
+  return {
+    ok: issues.length === 0,
+    cwd,
+    gitenvs: {
+      exists: gitenvsExists,
+      version,
+      latest,
+      stages: configuredStages,
+      envFiles:
+        gitenvs?.envFiles.map((envFile) => ({
+          name: envFile.name,
+          filePath: envFile.filePath,
+          type: envFile.type,
+        })) ?? [],
+    },
+    passphrases: {
+      path: passphrasePath,
+      exists: passphraseFile.exists,
+      valid: passphraseFile.valid,
+      stages: passphraseFile.stages,
+      missingStages: missingPassphrases,
+      extraStages: extraPassphrases,
+    },
+    gitignore,
+    packageJson,
+    ci: {
+      stageEnv: GITENVS_STAGE_ENV_NAME,
+      passphraseEnvByStage: Object.fromEntries(
+        configuredStages.map((stageName) => [
+          stageName,
+          getPassphraseEnvName({ stage: stageName }),
+        ]),
+      ) as Record<string, string>,
+    },
+    issues,
+  }
+}
+
+const printHumanStatus = (status: GitenvsStatus) => {
+  console.log(`Gitenvs status: ${status.ok ? 'ok' : 'needs attention'}`)
+  console.log(`cwd: ${status.cwd}`)
+  console.log(`gitenvs.json: ${status.gitenvs.exists ? 'found' : 'missing'}`)
+
+  if (status.gitenvs.exists) {
+    console.log(`version: ${status.gitenvs.version}`)
+    console.log(`stages: ${status.gitenvs.stages.join(', ') || '(none)'}`)
+    console.log(
+      `env files: ${
+        status.gitenvs.envFiles.map((envFile) => envFile.filePath).join(', ') ||
+        '(none)'
+      }`,
+    )
+  }
+
+  console.log(
+    `${PASSPHRASE_FILE_NAME}: ${
+      status.passphrases.exists ? 'found' : 'missing'
+    }`,
+  )
+
+  if (status.issues.length > 0) {
+    console.log('issues:')
+    for (const issue of status.issues) {
+      console.log(`- ${issue}`)
+    }
+  }
+}
+
+export const statusCommand = async (
+  options: z.infer<typeof statusCommandSchema>,
+) => {
+  const status = await collectStatus()
+
+  if (options.json) {
+    console.log(JSON.stringify(status, null, 2))
+    return
+  }
+
+  printHumanStatus(status)
+}

--- a/lib/cli/status/statusCommand.ts
+++ b/lib/cli/status/statusCommand.ts
@@ -6,7 +6,7 @@ import {
   checkGitenvsJsonExists,
   getGitenvs,
   getGitenvsVersion,
-  getIsLatestGitenvsVersion,
+  latestGitenvsVersion,
 } from '@/gitenvs/gitenvs'
 import { GITENVS_STAGE_ENV_NAME, getPassphraseEnvName } from '@/gitenvs/env'
 import { getCwd } from '@/gitenvs/getCwd'
@@ -26,6 +26,21 @@ const passphraseFileSchema = z.array(
   }),
 )
 
+const statusGitenvsSchema = z.object({
+  envStages: z.array(
+    z.object({
+      name: z.string(),
+    }),
+  ),
+  envFiles: z.array(
+    z.object({
+      name: z.string(),
+      filePath: z.string(),
+      type: z.string(),
+    }),
+  ),
+})
+
 export const statusCommandSchema = z.object({
   json: z.boolean().default(false),
 })
@@ -37,9 +52,16 @@ export const collectStatus = async () => {
   const passphrasePath = join(cwd, PASSPHRASE_FILE_NAME)
   const gitenvsExists = checkGitenvsJsonExists()
 
-  const gitenvs = gitenvsExists ? await getGitenvs() : null
   const version = gitenvsExists ? await getGitenvsVersion() : null
-  const latest = gitenvsExists ? await getIsLatestGitenvsVersion() : null
+  const latest = gitenvsExists ? version === latestGitenvsVersion : null
+  const currentGitenvs = gitenvsExists && latest ? await getGitenvs() : null
+  const statusGitenvs =
+    gitenvsExists && !latest
+      ? await readFile(join(cwd, 'gitenvs.json'), 'utf-8')
+          .then((content) => statusGitenvsSchema.safeParse(JSON.parse(content)))
+          .then((parsed) => (parsed.success ? parsed.data : null))
+          .catch(() => null)
+      : currentGitenvs
 
   const passphraseFile = await readFile(passphrasePath, 'utf-8')
     .then((content) => {
@@ -58,7 +80,8 @@ export const collectStatus = async () => {
       stages: [] as string[],
     }))
 
-  const configuredStages = gitenvs?.envStages.map((stage) => stage.name) ?? []
+  const configuredStages =
+    statusGitenvs?.envStages.map((stage) => stage.name) ?? []
   const missingPassphrases = configuredStages.filter(
     (stageName) => !passphraseFile.stages.includes(stageName),
   )
@@ -111,7 +134,7 @@ export const collectStatus = async () => {
       latest,
       stages: configuredStages,
       envFiles:
-        gitenvs?.envFiles.map((envFile) => ({
+        statusGitenvs?.envFiles.map((envFile) => ({
           name: envFile.name,
           filePath: envFile.filePath,
           type: envFile.type,


### PR DESCRIPTION
Chat: https://ai.sodefa.de/chats/j57bf0ggdyadegez238k25w04x88qkff

## Was ich geändert habe

- Headless `gitenvs setup` für Agenten/Skripte ergänzt, inklusive `gitenvs.json`, `gitenvs.passphrases.json`, `.gitignore` und optionaler Package-Wiring-Schritte.
- `gitenvs set` um `--value-env` und `--value-stdin` erweitert, damit Secrets nicht über argv übergeben werden müssen.
- Secret-sichere Commands `gitenvs status`, `gitenvs doctor`, `gitenvs passphrases validate` und `gitenvs ci env` ergänzt.
- README um Agent-Contract und bewusste Provider-Grenze erweitert: Bitwarden/Vercel/Neon bleiben in externen Agenten oder Wrappern.
- Tests für Setup, sichere Set-Inputs, Status-Metadaten und CI-Metadaten ergänzt.

## Warum

Neue Projekte sollen von Agents reproduzierbar vorbereitet werden können, ohne dass gitenvs SODEFA-spezifische Provider-Logik enthält. gitenvs liefert jetzt die lokalen, providerneutralen Primitive; SODEFA AI kann darauf aufbauend GitHub, Neon, Bitwarden und Vercel orchestrieren.

## Test plan

- [x] `pnpm exec vitest run`
- [x] `pnpm build-lib`
- [x] `pnpm build`