### PR TITLE
feat: add gitenvs run wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,12 +119,13 @@ A UI is automatically opened in your browser. Run through the wizard to set up g
     - `--stage <stage>` (default: development) - the stage to create the env files for (env var > cli param > default)
     - `--passphrase <passphrase>` - the passphrase to use for the stage (cli param > env var)
     - `--passphrasePath <passphrasePath>` - the path to the passphrase file
-- `gitenvs run --stage <stage> -- <command> [...args]` – run a program with decrypted env vars without writing `.env` files.
+- `gitenvs run --file <filePath> --stage <stage> -- <command> [...args]` – run a program with decrypted env vars without writing `.env` files.
   - This uses the same stage and passphrase lookup as `gitenvs create`: `GITENVS_STAGE`, `GITENVS_PASSPHRASE_<STAGE>`, `--passphrase`, or `--passphrasePath`.
+  - `--file <filePath>` selects the env file from `gitenvs.json`. It is optional only when the project has exactly one configured env file.
   - Gitenvs starts the child process directly with inherited `stdin`, `stdout`, and `stderr`, and exits with the child process exit code.
   - Put command options after `--` so they are passed through unchanged, for example:
     ```bash
-    gitenvs run --stage development -- npm run dev -- --host 0.0.0.0
+    gitenvs run --file apps/web/.env --stage development -- npm run dev -- --host 0.0.0.0
     ```
 - `gitenvs status` – print a secret-safe status summary. Add `--json` for machine-readable output.
 - `gitenvs doctor` – validate the local setup and exit non-zero if it finds issues. Add `--json` for machine-readable output.

--- a/README.md
+++ b/README.md
@@ -119,6 +119,13 @@ A UI is automatically opened in your browser. Run through the wizard to set up g
     - `--stage <stage>` (default: development) - the stage to create the env files for (env var > cli param > default)
     - `--passphrase <passphrase>` - the passphrase to use for the stage (cli param > env var)
     - `--passphrasePath <passphrasePath>` - the path to the passphrase file
+- `gitenvs run --stage <stage> -- <command> [...args]` – run a program with decrypted env vars without writing `.env` files.
+  - This uses the same stage and passphrase lookup as `gitenvs create`: `GITENVS_STAGE`, `GITENVS_PASSPHRASE_<STAGE>`, `--passphrase`, or `--passphrasePath`.
+  - Gitenvs starts the child process directly with inherited `stdin`, `stdout`, and `stderr`, and exits with the child process exit code.
+  - Put command options after `--` so they are passed through unchanged, for example:
+    ```bash
+    gitenvs run --stage development -- npm run dev -- --host 0.0.0.0
+    ```
 - `gitenvs status` – print a secret-safe status summary. Add `--json` for machine-readable output.
 - `gitenvs doctor` – validate the local setup and exit non-zero if it finds issues. Add `--json` for machine-readable output.
 - `gitenvs passphrases validate` – validate `gitenvs.passphrases.json` without printing passphrase values. Add `--json` for machine-readable output.

--- a/lib/cli/create/getFileContent.ts
+++ b/lib/cli/create/getFileContent.ts
@@ -1,10 +1,9 @@
-import { decryptEnvVar } from '@/gitenvs/decryptEnvVar'
 import {
   type EnvFile,
   type EnvStage,
-  type EnvVar,
   type Gitenvs,
 } from '@/gitenvs/gitenvs.schema'
+import { resolveEnvVars } from '../resolveEnvVars'
 
 export const getFileContent = async ({
   gitenvs,
@@ -17,13 +16,12 @@ export const getFileContent = async ({
   envStage: EnvStage
   passphrase: string
 }) => {
-  const resolvedEnvVars = (
-    await Promise.all(
-      gitenvs.envVars
-        .filter((envVar) => envVar.fileIds.includes(envFile.id))
-        .map(async (envVar) => resolveEnvVar({ envVar, envStage, passphrase })),
-    )
-  ).filter((dotenvVar) => !!dotenvVar.value)
+  const resolvedEnvVars = await resolveEnvVars({
+    gitenvs,
+    envFile,
+    envStage,
+    passphrase,
+  })
 
   const lines = resolvedEnvVars.map((envVar) => {
     console.log(`🔒 Gitenvs: Writing "${envVar.key}" to ${envFile.filePath}`)
@@ -39,49 +37,6 @@ export const getFileContent = async ({
   const fileContent = lines.join('\n')
 
   return fileContent
-}
-
-const resolveEnvVar = async ({
-  envVar,
-  envStage,
-  passphrase,
-}: {
-  envVar: EnvVar
-  envStage: EnvStage
-  passphrase: string
-}): Promise<{ key: string; value: string }> => {
-  const config = envVar.values[envStage.name]
-
-  if (!config) return { key: envVar.key, value: '' }
-
-  let value = config?.value ?? ''
-
-  if (config.encrypted) {
-    value =
-      (await decryptEnvVar({
-        encrypted: value,
-        encryptedPrivateKey: envStage.encryptedPrivateKey,
-        passphrase,
-      })) ?? ''
-  }
-
-  if (config.isFunction) {
-    try {
-      value = eval(value) // TODO: More secure way to evaluate functions
-      if (typeof value !== 'string') {
-        value = String(value)
-      }
-    } catch (error) {
-      console.error(`❌ Gitenvs: Error evaluating function "${envVar.key}"`)
-      console.error(error)
-      process.exit(1)
-    }
-  }
-
-  return {
-    key: envVar.key,
-    value,
-  }
 }
 
 const getDotenvLine = ({ key, value }: { key: string; value: string }) => {

--- a/lib/cli/main.ts
+++ b/lib/cli/main.ts
@@ -21,6 +21,7 @@ import {
   passphrasesValidateCommand,
   passphrasesValidateCommandSchema,
 } from './passphrases/passphrasesCommand'
+import { runCommand, runCommandSchema } from './run/runCommand'
 import { setCommand, setCommandSchema } from './set/setCommand'
 import { setupCommand, setupCommandSchema } from './setup/setupCommand'
 import { statusCommand, statusCommandSchema } from './status/statusCommand'
@@ -65,9 +66,16 @@ const checkGitenvsVersion = async () => {
 
 const program = new Command()
 
+type RunCommandCliOptions = {
+  stage?: string
+  passphrase?: string
+  passphrasePath?: string
+}
+
 program
   .name('gitenvs')
   .description('Save your env variables in git – encrypted!')
+  .enablePositionalOptions()
 
 program.command('migrate').action(async () => {
   let isLatestVersion = false
@@ -117,6 +125,41 @@ program.command('migrate').action(async () => {
     }
   }
 })
+
+program
+  .command('run')
+  .description('Runs a program with decrypted env vars without writing files')
+  .option(
+    '--stage <stage>',
+    'Example: production, staging, development',
+    'development',
+  )
+  .option('--passphrase <passphrase>')
+  .option('--passphrasePath <passphrasePath>')
+  .argument('<command>', 'Program to run')
+  .argument('[args...]', 'Arguments passed to the program')
+  .allowUnknownOption(true)
+  .passThroughOptions()
+  .action(
+    async (command: string, args: string[], options: RunCommandCliOptions) => {
+      await checkGitenvsVersion()
+
+      const parsed = runCommandSchema.safeParse({
+        ...options,
+        command,
+        args,
+      })
+
+      if (!parsed.success) {
+        console.error('❌ Gitenvs: Invalid options')
+        console.error(parsed.error.message)
+        process.exit(1)
+      }
+
+      const result = await runCommand(parsed.data)
+      process.exitCode = result.code
+    },
+  )
 
 program
   .command('create')

--- a/lib/cli/main.ts
+++ b/lib/cli/main.ts
@@ -67,6 +67,7 @@ const checkGitenvsVersion = async () => {
 const program = new Command()
 
 type RunCommandCliOptions = {
+  file?: string
   stage?: string
   passphrase?: string
   passphrasePath?: string
@@ -129,6 +130,10 @@ program.command('migrate').action(async () => {
 program
   .command('run')
   .description('Runs a program with decrypted env vars without writing files')
+  .option(
+    '--file <filePath>',
+    'Path of the env file from gitenvs.json (required when multiple env files are configured)',
+  )
   .option(
     '--stage <stage>',
     'Example: production, staging, development',

--- a/lib/cli/resolveEnvVars.ts
+++ b/lib/cli/resolveEnvVars.ts
@@ -1,0 +1,75 @@
+import { decryptEnvVar } from '@/gitenvs/decryptEnvVar'
+import {
+  type EnvFile,
+  type EnvStage,
+  type EnvVar,
+  type Gitenvs,
+} from '@/gitenvs/gitenvs.schema'
+
+export type ResolvedEnvVar = {
+  key: string
+  value: string
+}
+
+export const resolveEnvVars = async ({
+  gitenvs,
+  envFile,
+  envStage,
+  passphrase,
+}: {
+  gitenvs: Gitenvs
+  envFile?: EnvFile
+  envStage: EnvStage
+  passphrase: string
+}) => {
+  return (
+    await Promise.all(
+      gitenvs.envVars
+        .filter((envVar) => !envFile || envVar.fileIds.includes(envFile.id))
+        .map(async (envVar) => resolveEnvVar({ envVar, envStage, passphrase })),
+    )
+  ).filter((envVar) => !!envVar.value)
+}
+
+const resolveEnvVar = async ({
+  envVar,
+  envStage,
+  passphrase,
+}: {
+  envVar: EnvVar
+  envStage: EnvStage
+  passphrase: string
+}): Promise<ResolvedEnvVar> => {
+  const config = envVar.values[envStage.name]
+
+  if (!config) return { key: envVar.key, value: '' }
+
+  let value = config.value ?? ''
+
+  if (config.encrypted) {
+    value =
+      (await decryptEnvVar({
+        encrypted: value,
+        encryptedPrivateKey: envStage.encryptedPrivateKey,
+        passphrase,
+      })) ?? ''
+  }
+
+  if (config.isFunction) {
+    try {
+      value = eval(value) // TODO: More secure way to evaluate functions
+      if (typeof value !== 'string') {
+        value = String(value)
+      }
+    } catch (error) {
+      console.error(`❌ Gitenvs: Error evaluating function "${envVar.key}"`)
+      console.error(error)
+      process.exit(1)
+    }
+  }
+
+  return {
+    key: envVar.key,
+    value,
+  }
+}

--- a/lib/cli/run/runCommand.test.ts
+++ b/lib/cli/run/runCommand.test.ts
@@ -96,6 +96,97 @@ const writeTestProject = async () => {
   return testDir
 }
 
+const writeMultiFileProject = async () => {
+  testDir = await mkdtemp(join(tmpdir(), 'gitenvs-run-'))
+  process.env[GITENVS_DIR_ENV_NAME] = testDir
+
+  const keys = await createKeys()
+  const gitenvs = {
+    version: '2',
+    envStages: [
+      {
+        name: 'development',
+        publicKey: keys.publicKey,
+        encryptedPrivateKey: keys.encryptedPrivateKey,
+      },
+    ],
+    envFiles: [
+      {
+        id: 'envFile_web',
+        name: 'apps/web/.env',
+        filePath: 'apps/web/.env',
+        type: 'dotenv',
+      },
+      {
+        id: 'envFile_worker',
+        name: 'apps/worker/.env',
+        filePath: 'apps/worker/.env',
+        type: 'dotenv',
+      },
+    ],
+    envVars: [
+      {
+        id: 'envVar_shared',
+        fileIds: ['envFile_web', 'envFile_worker'],
+        key: 'SHARED_SECRET',
+        values: {
+          development: {
+            value: 'shared',
+            encrypted: false,
+          },
+        },
+      },
+      {
+        id: 'envVar_web',
+        fileIds: ['envFile_web'],
+        key: 'APP_SECRET',
+        values: {
+          development: {
+            value: 'web-secret',
+            encrypted: false,
+          },
+        },
+      },
+      {
+        id: 'envVar_worker',
+        fileIds: ['envFile_worker'],
+        key: 'APP_SECRET',
+        values: {
+          development: {
+            value: 'worker-secret',
+            encrypted: false,
+          },
+        },
+      },
+      {
+        id: 'envVar_worker_only',
+        fileIds: ['envFile_worker'],
+        key: 'WORKER_ONLY',
+        values: {
+          development: {
+            value: 'yes',
+            encrypted: false,
+          },
+        },
+      },
+    ],
+  } satisfies Gitenvs
+  const passphrases = [
+    {
+      stageName: 'development',
+      passphrase: keys.passphrase,
+    },
+  ] satisfies Passphrase[]
+
+  await writeFile(join(testDir, 'gitenvs.json'), JSON.stringify(gitenvs))
+  await writeFile(
+    join(testDir, PASSPHRASE_FILE_NAME),
+    JSON.stringify(passphrases),
+  )
+
+  return testDir
+}
+
 test('builds a child environment without creating env files', async () => {
   const dir = await writeTestProject()
   process.env.API_KEY = 'parent-value'
@@ -109,6 +200,21 @@ test('builds a child environment without creating env files', async () => {
   expect(env.API_KEY).toBe('secret-from-gitenvs')
   expect(env.PLAIN_FLAG).toBe('enabled')
   await expect(access(join(dir, '.env'))).rejects.toThrow()
+})
+
+test('builds a child environment from the selected env file', async () => {
+  await writeMultiFileProject()
+
+  const env = await buildRunEnvironment({
+    file: 'apps/web/.env',
+    stage: 'development',
+    command: 'node',
+    args: [],
+  })
+
+  expect(env.SHARED_SECRET).toBe('shared')
+  expect(env.APP_SECRET).toBe('web-secret')
+  expect(env.WORKER_ONLY).toBeUndefined()
 })
 
 test('spawns the command with inherited stdio and returns the child exit code', async () => {
@@ -168,6 +274,27 @@ test('CLI run passes args through quietly and returns the child exit code', asyn
     stderr: '',
   })
   await expect(access(join(dir, '.env'))).rejects.toThrow()
+})
+
+test('CLI run requires --file when multiple env files are configured', async () => {
+  await writeMultiFileProject()
+
+  const result = await runCli([
+    'run',
+    '--stage',
+    'development',
+    '--',
+    'node',
+    '-e',
+    'process.exit(0)',
+  ])
+
+  expect(result.code).toBe(1)
+  expect(result.stdout).toBe('')
+  expect(result.stderr).toContain(
+    'Multiple env files are configured. Pass --file <filePath>.',
+  )
+  expect(result.stderr).toContain('apps/web/.env, apps/worker/.env')
 })
 
 const runCli = async (args: string[]) => {

--- a/lib/cli/run/runCommand.test.ts
+++ b/lib/cli/run/runCommand.test.ts
@@ -1,0 +1,206 @@
+import { createKeys } from '@/gitenvs/createKeys'
+import { encryptEnvVar } from '@/gitenvs/encryptEnvVar'
+import { GITENVS_DIR_ENV_NAME } from '@/gitenvs/env'
+import { type Gitenvs, type Passphrase } from '@/gitenvs/gitenvs.schema'
+import { PASSPHRASE_FILE_NAME } from '@/gitenvs/getPassphrase'
+import {
+  spawn as spawnChildProcess,
+  type ChildProcess,
+  type SpawnOptions,
+} from 'child_process'
+import { EventEmitter } from 'events'
+import { access, mkdtemp, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, expect, test, vi } from 'vitest'
+import { buildRunEnvironment, runCommand } from './runCommand'
+
+let testDir: string | undefined
+
+afterEach(async () => {
+  delete process.env[GITENVS_DIR_ENV_NAME]
+  delete process.env.GITENVS_STAGE
+  delete process.env.API_KEY
+  delete process.env.PLAIN_FLAG
+  vi.restoreAllMocks()
+
+  if (testDir) {
+    await rm(testDir, { recursive: true, force: true })
+    testDir = undefined
+  }
+})
+
+const writeTestProject = async () => {
+  testDir = await mkdtemp(join(tmpdir(), 'gitenvs-run-'))
+  process.env[GITENVS_DIR_ENV_NAME] = testDir
+
+  const keys = await createKeys()
+  const gitenvs = {
+    version: '2',
+    envStages: [
+      {
+        name: 'development',
+        publicKey: keys.publicKey,
+        encryptedPrivateKey: keys.encryptedPrivateKey,
+      },
+    ],
+    envFiles: [
+      {
+        id: 'envFile_6Gv71d0ZenuC9N39CeGz1c',
+        name: '.env',
+        filePath: '.env',
+        type: 'dotenv',
+      },
+    ],
+    envVars: [
+      {
+        id: 'envVar_8r2GLmGTIxyKrQAvkOSREt',
+        fileIds: ['envFile_6Gv71d0ZenuC9N39CeGz1c'],
+        key: 'API_KEY',
+        values: {
+          development: {
+            value: await encryptEnvVar({
+              plaintext: 'secret-from-gitenvs',
+              publicKey: keys.publicKey,
+            }),
+            encrypted: true,
+          },
+        },
+      },
+      {
+        id: 'envVar_M22bHTUUs0FAEUWBF8eSqp',
+        fileIds: ['envFile_6Gv71d0ZenuC9N39CeGz1c'],
+        key: 'PLAIN_FLAG',
+        values: {
+          development: {
+            value: 'enabled',
+            encrypted: false,
+          },
+        },
+      },
+    ],
+  } satisfies Gitenvs
+  const passphrases = [
+    {
+      stageName: 'development',
+      passphrase: keys.passphrase,
+    },
+  ] satisfies Passphrase[]
+
+  await writeFile(join(testDir, 'gitenvs.json'), JSON.stringify(gitenvs))
+  await writeFile(
+    join(testDir, PASSPHRASE_FILE_NAME),
+    JSON.stringify(passphrases),
+  )
+
+  return testDir
+}
+
+test('builds a child environment without creating env files', async () => {
+  const dir = await writeTestProject()
+  process.env.API_KEY = 'parent-value'
+
+  const env = await buildRunEnvironment({
+    stage: 'development',
+    command: 'node',
+    args: [],
+  })
+
+  expect(env.API_KEY).toBe('secret-from-gitenvs')
+  expect(env.PLAIN_FLAG).toBe('enabled')
+  await expect(access(join(dir, '.env'))).rejects.toThrow()
+})
+
+test('spawns the command with inherited stdio and returns the child exit code', async () => {
+  await writeTestProject()
+  const child = new EventEmitter() as ChildProcess
+  child.kill = vi.fn()
+  child.killed = false
+
+  const spawnProcess = vi.fn(
+    (_command: string, _args: readonly string[], _options: SpawnOptions) =>
+      child,
+  )
+
+  const resultPromise = runCommand(
+    {
+      stage: 'development',
+      command: 'node',
+      args: ['script.js', '--flag', 'value'],
+    },
+    spawnProcess,
+  )
+
+  await vi.waitFor(() => expect(spawnProcess).toHaveBeenCalled())
+  child.emit('exit', 7, null)
+
+  await expect(resultPromise).resolves.toEqual({ code: 7 })
+  expect(spawnProcess).toHaveBeenCalledWith(
+    'node',
+    ['script.js', '--flag', 'value'],
+    expect.objectContaining({
+      stdio: 'inherit',
+      env: expect.objectContaining({
+        API_KEY: 'secret-from-gitenvs',
+        PLAIN_FLAG: 'enabled',
+      }),
+    }),
+  )
+})
+
+test('CLI run passes args through quietly and returns the child exit code', async () => {
+  const dir = await writeTestProject()
+  const result = await runCli([
+    'run',
+    '--stage',
+    'development',
+    '--',
+    'node',
+    '-e',
+    'process.exit(process.env.API_KEY === "secret-from-gitenvs" && process.argv[1] === "--child-flag" ? 23 : 42)',
+    '--',
+    '--child-flag',
+  ])
+
+  expect(result).toEqual({
+    code: 23,
+    stdout: '',
+    stderr: '',
+  })
+  await expect(access(join(dir, '.env'))).rejects.toThrow()
+})
+
+const runCli = async (args: string[]) => {
+  return new Promise<{
+    code: number
+    stdout: string
+    stderr: string
+  }>((resolve, reject) => {
+    const child = spawnChildProcess(
+      'pnpm',
+      ['exec', 'tsx', 'lib/cli/main.ts', ...args],
+      {
+        cwd: process.cwd(),
+        env: process.env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    )
+    let stdout = ''
+    let stderr = ''
+
+    child.stdout.on('data', (chunk) => {
+      stdout += String(chunk)
+    })
+    child.stderr.on('data', (chunk) => {
+      stderr += String(chunk)
+    })
+    child.once('error', reject)
+    child.once('close', (code) => {
+      resolve({
+        code: code ?? 1,
+        stdout,
+        stderr,
+      })
+    })
+  })
+}

--- a/lib/cli/run/runCommand.ts
+++ b/lib/cli/run/runCommand.ts
@@ -10,6 +10,7 @@ import { z } from 'zod'
 import { resolveEnvVars } from '../resolveEnvVars'
 
 export const runCommandSchema = z.object({
+  file: z.string().optional(),
   stage: z.string().default('development'),
   passphrase: z.string().optional(),
   passphrasePath: z.string().optional(),
@@ -78,6 +79,10 @@ export const buildRunEnvironment = async (options: RunCommandOptions) => {
 
   const resolvedEnvVars = await resolveEnvVars({
     gitenvs,
+    envFile: resolveRunEnvFile({
+      file: options.file,
+      envFiles: gitenvs.envFiles,
+    }),
     envStage,
     passphrase,
   })
@@ -164,6 +169,39 @@ const waitForChildProcess = async ({
     })
   })
 }
+
+const resolveRunEnvFile = ({
+  file,
+  envFiles,
+}: {
+  file?: string
+  envFiles: Awaited<ReturnType<typeof getGitenvs>>['envFiles']
+}) => {
+  if (file) {
+    const envFile = envFiles.find((envFile) => envFile.filePath === file)
+    if (!envFile) {
+      console.error(
+        `❌ Gitenvs: Env file ${file} not found. Available: ${formatAvailableEnvFiles(envFiles)}`,
+      )
+      process.exit(1)
+    }
+
+    return envFile
+  }
+
+  if (envFiles.length === 1) {
+    return envFiles[0]
+  }
+
+  console.error(
+    `❌ Gitenvs: Multiple env files are configured. Pass --file <filePath>. Available: ${formatAvailableEnvFiles(envFiles)}`,
+  )
+  process.exit(1)
+}
+
+const formatAvailableEnvFiles = (
+  envFiles: Awaited<ReturnType<typeof getGitenvs>>['envFiles'],
+) => envFiles.map((envFile) => envFile.filePath).join(', ') || '(none)'
 
 const getSignalExitCode = (signal: NodeJS.Signals) => {
   const signalNumber = osConstants.signals[signal]

--- a/lib/cli/run/runCommand.ts
+++ b/lib/cli/run/runCommand.ts
@@ -1,0 +1,171 @@
+import { GITENVS_STAGE_ENV_NAME } from '@/gitenvs/env'
+import { getCwd } from '@/gitenvs/getCwd'
+import { getIsGitenvsExisting } from '@/gitenvs/getIsGitenvsExisting'
+import { getPassphrase, PASSPHRASE_FILE_NAME } from '@/gitenvs/getPassphrase'
+import { getGitenvs, getIsLatestGitenvsVersion } from '@/gitenvs/gitenvs'
+import { spawn, type ChildProcess, type SpawnOptions } from 'child_process'
+import { constants as osConstants } from 'os'
+import { join } from 'path'
+import { z } from 'zod'
+import { resolveEnvVars } from '../resolveEnvVars'
+
+export const runCommandSchema = z.object({
+  stage: z.string().default('development'),
+  passphrase: z.string().optional(),
+  passphrasePath: z.string().optional(),
+  command: z.string().min(1),
+  args: z.array(z.string()).default([]),
+})
+
+export type RunCommandOptions = z.infer<typeof runCommandSchema>
+
+export type RunCommandResult = {
+  code: number
+  signal?: NodeJS.Signals
+}
+
+type SpawnProcess = (
+  command: string,
+  args: readonly string[],
+  options: SpawnOptions,
+) => ChildProcess
+
+export const buildRunEnvironment = async (options: RunCommandOptions) => {
+  const gitenvsExists = await getIsGitenvsExisting()
+  if (!gitenvsExists) {
+    console.error('❌ Gitenvs: gitenvs.json not found')
+    process.exit(1)
+  }
+
+  const isLatestGitenvsVersion = await getIsLatestGitenvsVersion()
+  if (!isLatestGitenvsVersion) {
+    console.error(
+      `❌ Gitenvs: Version is not latest. Please run \`gitenvs migrate\` to migrate to the latest version.`,
+    )
+    process.exit(1)
+  }
+
+  const gitenvs = await getGitenvs()
+  const stage = process.env[GITENVS_STAGE_ENV_NAME] ?? options.stage
+
+  if (!stage) {
+    console.error(
+      `Stage is required. Set it with --stage <stage> or with env var: ${GITENVS_STAGE_ENV_NAME}`,
+    )
+    process.exit(1)
+  }
+
+  const envStage = gitenvs.envStages.find((envStage) => envStage.name === stage)
+  if (!envStage) {
+    console.error(`Env stage ${stage} not found`)
+    process.exit(1)
+  }
+
+  const passphrase = await getPassphrase({
+    stage,
+    passphrase: options.passphrase,
+    passphrasePath: options.passphrasePath,
+  })
+
+  if (!passphrase) {
+    console.error(
+      `Requested passphrase for stage ${stage} not found in ${
+        options.passphrasePath ?? join(getCwd(), PASSPHRASE_FILE_NAME)
+      }`,
+    )
+    process.exit(1)
+  }
+
+  const resolvedEnvVars = await resolveEnvVars({
+    gitenvs,
+    envStage,
+    passphrase,
+  })
+
+  return {
+    ...process.env,
+    ...Object.fromEntries(
+      resolvedEnvVars.map((envVar) => [envVar.key, envVar.value]),
+    ),
+  }
+}
+
+export const runCommand = async (
+  options: RunCommandOptions,
+  spawnProcess: SpawnProcess = spawn,
+): Promise<RunCommandResult> => {
+  const env = await buildRunEnvironment(options)
+  const child = spawnProcess(options.command, options.args, {
+    stdio: 'inherit',
+    env,
+  })
+
+  return waitForChildProcess({
+    child,
+    command: options.command,
+  })
+}
+
+const waitForChildProcess = async ({
+  child,
+  command,
+}: {
+  child: ChildProcess
+  command: string
+}): Promise<RunCommandResult> => {
+  const forwardedSignals: NodeJS.Signals[] = ['SIGINT', 'SIGTERM', 'SIGHUP']
+  const signalListeners = forwardedSignals.map((signal) => ({
+    signal,
+    listener: () => {
+      if (!child.killed) {
+        child.kill(signal)
+      }
+    },
+  }))
+
+  signalListeners.forEach(({ signal, listener }) => {
+    process.once(signal, listener)
+  })
+
+  const cleanup = () => {
+    signalListeners.forEach(({ signal, listener }) => {
+      process.off(signal, listener)
+    })
+  }
+
+  return new Promise((resolve) => {
+    let settled = false
+    const finish = (result: RunCommandResult) => {
+      if (settled) return
+      settled = true
+      cleanup()
+      resolve(result)
+    }
+
+    child.once('error', (error: NodeJS.ErrnoException) => {
+      console.error(
+        `❌ Gitenvs: Failed to start "${command}": ${error.message}`,
+      )
+      finish({ code: error.code === 'ENOENT' ? 127 : 1 })
+    })
+
+    child.once('exit', (code, signal) => {
+      if (typeof code === 'number') {
+        finish({ code })
+        return
+      }
+
+      if (signal) {
+        finish({ code: getSignalExitCode(signal), signal })
+        return
+      }
+
+      finish({ code: 1 })
+    })
+  })
+}
+
+const getSignalExitCode = (signal: NodeJS.Signals) => {
+  const signalNumber = osConstants.signals[signal]
+  return signalNumber ? 128 + signalNumber : 1
+}


### PR DESCRIPTION
Chat: https://ai.sodefa.de/chats/j570gpryhfrvvpnprmr5362rr5890036

## Was ich geändert habe

- `gitenvs run --file <filePath> --stage <stage> -- <command> [...args]` ergänzt, ohne `.env`-Dateien zu schreiben.
- `--file` wählt das Env-File aus `gitenvs.json`; bei genau einem konfigurierten Env-File ist es optional, bei mehreren bricht `run` ohne `--file` mit einer klaren Fehlermeldung ab.
- Env-Auflösung aus `create` in einen gemeinsamen Resolver verschoben, damit `create` und `run` denselben Decrypt-/Function-Flow nutzen.
- Child-Prozess wird direkt per `spawn` mit `stdio: inherit` gestartet; Args, stdin/stdout/stderr, Signale und Exit-Code werden durchgereicht.
- README und Tests für Env-Injection, kein Datei-Write, File-Filterung, Multi-File-Fehler, Args-Passthrough, leise CLI-Ausgabe und Exit-Code-Passthrough ergänzt.

## Warum

Damit Programme mit gitenvs-Env laufen können, ohne vorher `.env` oder `.ts`-Env-Dateien zu generieren. Die File-Auswahl verhindert bei Multi-File-Projekten stille Key-Kollisionen und lädt nur die Variablen, die zu dem gestarteten Programm gehören.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm vitest run`
- [x] `pnpm build-lib`